### PR TITLE
Fix authorization code parsing

### DIFF
--- a/Bitmonet/src/com/bitmonet/Constants.java
+++ b/Bitmonet/src/com/bitmonet/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
 	public static final String COINBASE_REQUEST_TOKEN_URL = "https://coinbase.com/oauth/token?grant_type=authorization_code&code=";
 	public static final String COINBASE_SEND_MONEY_URI = "https://coinbase.com/api/v1/transactions/";
 	public static final String COINBASE_REFRESH_TOKEN_URL = "https://coinbase.com/oauth/token?grant_type=refresh_token&refresh_token=";
-	public static final String COINBASE_AUTH_RESPONSE_URL_SUFFIX = "?code=";
+	public static final String COINBASE_AUTH_RESPONSE_URL_SUFFIX = "/authorize/";
 
 	/*
 	 * Coinbase JSON paramneters

--- a/Bitmonet/src/com/bitmonet/coinbase/CoinbaseWebView.java
+++ b/Bitmonet/src/com/bitmonet/coinbase/CoinbaseWebView.java
@@ -65,7 +65,7 @@ public class CoinbaseWebView extends Activity {
 		}
 
 		private String getCode(String url) {
-			return url.substring((Bitmonet.getCallbackUrl() + "/" + Constants.COINBASE_AUTH_RESPONSE_URL_SUFFIX).length());
+			return url.substring(url.indexOf(Constants.COINBASE_AUTH_RESPONSE_URL_SUFFIX) + Constants.COINBASE_AUTH_RESPONSE_URL_SUFFIX.length());
 		}
 	}
 


### PR DESCRIPTION
Authorization codes appear to now be returned in the below format.  This pull-request should fix the library to handle this correctly.

`https://www.coinbase.com/oauth/authorize/:code`
